### PR TITLE
Bug fixes and support for TFS 2013

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -3,7 +3,7 @@
 <Project>
   <PropertyGroup>
     <!-- This repo version -->
-    <VersionPrefix>1.2.0</VersionPrefix>
+    <VersionPrefix>1.2.0.3</VersionPrefix>
     <PreReleaseVersionLabel>beta</PreReleaseVersionLabel>
     <SemanticVersioningV1>true</SemanticVersioningV1>
     <!-- Opt-in repo features -->
@@ -11,7 +11,7 @@
     <UsingToolSymbolUploader>true</UsingToolSymbolUploader>
     <MicrosoftBuildVersion>16.7.0</MicrosoftBuildVersion>
     <MicrosoftBuildTasksCore>16.7.0</MicrosoftBuildTasksCore>
-    <MicrosoftTeamFoundationServerExtendedClientVersion>19.210.0-preview</MicrosoftTeamFoundationServerExtendedClientVersion>
+    <MicrosoftTeamFoundationServerExtendedClientVersion>16.170.0</MicrosoftTeamFoundationServerExtendedClientVersion> <!-- v16.170.0 is compatible with TFS 2013 -->
     <MicrosoftDotNetPlatformAbstractionsVersion>3.1.6</MicrosoftDotNetPlatformAbstractionsVersion>
     <NuGetVersioningVersion>5.7.0</NuGetVersioningVersion>
     <NuGetPackagingVersion>5.7.0</NuGetPackagingVersion>

--- a/src/Microsoft.Build.Tasks.Tfvc/GetSourceRoots.cs
+++ b/src/Microsoft.Build.Tasks.Tfvc/GetSourceRoots.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Build.Tasks.Tfvc
         ///   RevisionId: Revision (changeset number).
         /// </summary>
         [Output]
-        public ITaskItem[]? Mapping { get; private set; }
+        public ITaskItem[]? Roots { get; private set; }
 
         protected override bool Execute(WorkspaceInfo workspaceInfo)
         {
@@ -55,7 +55,12 @@ namespace Microsoft.Build.Tasks.Tfvc
 
                     // SourceLink.AzureRepos will map each source root to:
                     // {RepositoryUrl}/_versionControl?path={ServerPath}&version={RevisionId}
-                    var item = new TaskItem(folder.LocalItem);
+
+                    // SourceRoot paths are required to end with a slash or backslash
+                    var sourceRoot = folder.LocalItem.EndsWithSeparator()
+                        ? folder.LocalItem
+                        : $"{folder.LocalItem}{Path.DirectorySeparatorChar}";
+                    var item = new TaskItem(sourceRoot);
                     item.SetMetadata("SourceControl", "tfvc");
                     item.SetMetadata("CollectionUrl", collectionUrl);
                     item.SetMetadata("ProjectId", projectId);
@@ -65,7 +70,7 @@ namespace Microsoft.Build.Tasks.Tfvc
                 }
             }
 
-            Mapping = result.ToArray();
+            Roots = result.ToArray();
             return true;
         }
     }


### PR DESCRIPTION
- [x] Bump version to `1.2.0.3`
- [x] Downgrade TF NuGet for TFS 2013 compatibility
- [x] Fix bug in `GetSourceRoots` task